### PR TITLE
fix: readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ graph TD
 
 ## Overview
 
-A simple service that keeps your Apollo Federation supergraph updated by continuously fetching subgraph schemas and composing them. The generated supergraph schema is designed to be consumed by GraphQL gateways like Apollo Router, Hive Gateway, or Apollo Federation Gateway. Optionally publishes schema changes to a registry (GraphQL Hive). Built with NestJS and TypeScript.
+A simple service that keeps your Apollo Federation supergraph updated by continuously fetching subgraph schemas and composing them. The generated supergraph schema is designed to be consumed by GraphQL gateways like Apollo Router or Hive Gateway. Optionally publishes schema changes to a registry (GraphQL Hive). Built with NestJS and TypeScript.
 
 ### Features
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Updated README Overview to clarify supported GraphQL gateways, replacing “Apollo Federation Gateway” with “Apollo Router or Hive Gateway.” Aligns documentation with current support and helps users choose the correct setup. Improves accuracy and reduces confusion during deployment and configuration. No functional or API changes; no action required unless you were referencing the deprecated gateway in your internal docs or setup notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->