### PR TITLE
chore: version

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ docker run -d \
   -p 8080:8080 \
   -e SUBGRAPH_MYPROJECT_USERS=http://users-service:4001/graphql \
   -e SUBGRAPH_MYPROJECT_PRODUCTS=http://products-service:4002/graphql \
-  revisium/supergraph-builder:v0.2.1
+  revisium/supergraph-builder:v0.2.2
 ```
 
 2. **Get your supergraph**:
@@ -88,7 +88,7 @@ curl http://localhost:8080/supergraph/myproject
 version: '3.8'
 services:
   supergraph-builder:
-    image: revisium/supergraph-builder:v0.2.1
+    image: revisium/supergraph-builder:v0.2.2
     ports:
       - '8080:8080'
     environment:
@@ -112,7 +112,7 @@ Create a `values.yaml` file:
 # values.yaml
 image:
   repository: revisium/supergraph-builder
-  tag: v0.2.1
+  tag: v0.2.2
   pullPolicy: IfNotPresent
 
 service:
@@ -229,7 +229,7 @@ spec:
     spec:
       containers:
         - name: supergraph-builder
-          image: revisium/supergraph-builder:v0.2.1
+          image: revisium/supergraph-builder:v0.2.2
           ports:
             - containerPort: 8080
           env:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated README to reference Docker image tag v0.2.2 across all examples, including Docker usage, Helm values, and Kubernetes deployment snippets.
  - Ensures users pull the latest release when following setup instructions, improving accuracy and reducing confusion.
  - No behavioral or configuration changes to the application; examples only reflect the new image tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->