### PR TITLE
Support federation v2.12 in composition

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ graph TD
 
 A simple service that keeps your Apollo Federation supergraph updated by continuously fetching subgraph schemas and composing them. The generated supergraph schema is designed to be consumed by GraphQL gateways like Apollo Router or Hive Gateway. Optionally publishes schema changes to a registry (GraphQL Hive). Built with NestJS and TypeScript.
 
-Supported Apollo Federation subgraph `@link` versions: `v2.3` through `v2.12+` (verified against `@apollo/composition` `2.14.0`).
+Supported Apollo Federation subgraph `@link` versions: `v2.3` through `v2.12` (verified against `@apollo/composition` `2.14.0`).
 
 ### Features
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ graph TD
 
 A simple service that keeps your Apollo Federation supergraph updated by continuously fetching subgraph schemas and composing them. The generated supergraph schema is designed to be consumed by GraphQL gateways like Apollo Router or Hive Gateway. Optionally publishes schema changes to a registry (GraphQL Hive). Built with NestJS and TypeScript.
 
+Supported Apollo Federation subgraph `@link` versions: `v2.3` through `v2.12+` (verified against `@apollo/composition` `2.14.0`).
+
 ### Features
 
 - **Continuous Schema Fetching** - Polls subgraph endpoints to keep schemas up-to-date

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,12 +7,12 @@
     "": {
       "name": "supergraph-builder",
       "version": "0.2.0",
-      "license": "UNLICENSED",
+      "license": "MIT",
       "dependencies": {
-        "@apollo/composition": "^2.11.2",
-        "@apollo/federation-internals": "^2.11.2",
+        "@apollo/composition": "^2.14.0",
+        "@apollo/federation-internals": "^2.14.0",
         "@apollo/query-graphs": "^2.11.2",
-        "@apollo/subgraph": "^2.11.2",
+        "@apollo/subgraph": "^2.14.0",
         "@nestjs/axios": "^4.0.0",
         "@nestjs/common": "^11.0.1",
         "@nestjs/config": "^4.0.2",
@@ -223,25 +223,25 @@
       }
     },
     "node_modules/@apollo/composition": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@apollo/composition/-/composition-2.11.2.tgz",
-      "integrity": "sha512-ut/Kj/YMUXtV+VwsHFOoT0hvvZAJwOltkuMVZJUY1O0deecrc4Ceq8VeogPKXF/jeR59kMr6na1ZPHBRBe/rqQ==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@apollo/composition/-/composition-2.14.0.tgz",
+      "integrity": "sha512-IPxU1zZkoUlVRWCZFQ4n2Ela+F8euHualZNdQ3vaeBIGLYVJDMcfL3/CaXZ717Taa/6DrxkjfKQiuJd12oL7rQ==",
       "license": "Elastic-2.0",
       "dependencies": {
-        "@apollo/federation-internals": "2.11.2",
-        "@apollo/query-graphs": "2.11.2"
+        "@apollo/federation-internals": "2.14.0",
+        "@apollo/query-graphs": "2.14.0"
       },
       "engines": {
-        "node": ">=14.15.0"
+        "node": ">=18"
       },
       "peerDependencies": {
         "graphql": "^16.5.0"
       }
     },
     "node_modules/@apollo/federation-internals": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@apollo/federation-internals/-/federation-internals-2.11.2.tgz",
-      "integrity": "sha512-GSFGL2fLox3EBszWKJvRkVLFA0hkJF9PHGMQH+WdB/12KVB3QHKwDyW1T9VZtxe2SJhNU3puleSxCsO16Bf3iA==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@apollo/federation-internals/-/federation-internals-2.14.0.tgz",
+      "integrity": "sha512-Kw1vfyTU3oG38HkmYym+QGtebdTg1fcEfsjdIjJFKQXgYa/fTwr+NZcfT4FHli8ws9WNvCp+f5pUuklM2e9OHQ==",
       "license": "Elastic-2.0",
       "dependencies": {
         "@types/uuid": "^9.0.0",
@@ -250,38 +250,38 @@
         "uuid": "^9.0.0"
       },
       "engines": {
-        "node": ">=14.15.0"
+        "node": ">=18"
       },
       "peerDependencies": {
         "graphql": "^16.5.0"
       }
     },
     "node_modules/@apollo/query-graphs": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@apollo/query-graphs/-/query-graphs-2.11.2.tgz",
-      "integrity": "sha512-LwGumh0XkOMSA4+RhSVYY1Yd4wa3Mi8ylDk8GyhMl4kpFAOb2x+SRIka+kEDNPufu9wNSl457/rVeAxNw1zZ1Q==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@apollo/query-graphs/-/query-graphs-2.14.0.tgz",
+      "integrity": "sha512-s88QftWzFCFfUq+7Tzje5I8Rrh/ntX2E0Mq8uOh625ffPE1m92kRga3Zmxouca0ancJwymeVQ4w4hif2UbLEXA==",
       "license": "Elastic-2.0",
       "dependencies": {
-        "@apollo/federation-internals": "2.11.2",
+        "@apollo/federation-internals": "2.14.0",
         "deep-equal": "^2.0.5",
         "ts-graphviz": "^1.5.4",
         "uuid": "^9.0.0"
       },
       "engines": {
-        "node": ">=14.15.0"
+        "node": ">=18"
       },
       "peerDependencies": {
         "graphql": "^16.5.0"
       }
     },
     "node_modules/@apollo/subgraph": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@apollo/subgraph/-/subgraph-2.11.2.tgz",
-      "integrity": "sha512-S14osF5Zc8pd6lzeNtX1QHboMcQK5PXcN9EumZyRYBF0TRbnEFLF8Me9zMcfR3QP7GCiggjd6PA2IAaPC9uCSQ==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@apollo/subgraph/-/subgraph-2.14.0.tgz",
+      "integrity": "sha512-hG/KFcC9FMihf8Zy181EZIioW26e7iqsOojEoB74kmLaBRXs+cYqb7Eba8u1mfI34S2F1VzbODSvWNQn4J3W0Q==",
       "license": "MIT",
       "dependencies": {
         "@apollo/cache-control-types": "^1.0.2",
-        "@apollo/federation-internals": "2.11.2"
+        "@apollo/federation-internals": "2.14.0"
       },
       "engines": {
         "node": ">=14.15.0"

--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
-    "@apollo/composition": "^2.11.2",
-    "@apollo/federation-internals": "^2.11.2",
+    "@apollo/composition": "^2.14.0",
+    "@apollo/federation-internals": "^2.14.0",
     "@apollo/query-graphs": "^2.11.2",
-    "@apollo/subgraph": "^2.11.2",
+    "@apollo/subgraph": "^2.14.0",
     "@nestjs/axios": "^4.0.0",
     "@nestjs/common": "^11.0.1",
     "@nestjs/config": "^4.0.2",

--- a/src/supergraph/__tests__/federation-link-v212.spec.ts
+++ b/src/supergraph/__tests__/federation-link-v212.spec.ts
@@ -2,7 +2,7 @@ import { composeServices } from '@apollo/composition';
 
 describe('Apollo Federation link compatibility', () => {
   it('composes mixed federation v2.12 and v2.3 subgraphs', () => {
-    const { parse } = jest.requireActual('graphql') as typeof import('graphql');
+    const { parse } = jest.requireActual<typeof import('graphql')>('graphql');
 
     const result = composeServices([
       {

--- a/src/supergraph/__tests__/federation-link-v212.spec.ts
+++ b/src/supergraph/__tests__/federation-link-v212.spec.ts
@@ -1,0 +1,53 @@
+import { composeServices } from '@apollo/composition';
+
+describe('Apollo Federation link compatibility', () => {
+  it('composes mixed federation v2.12 and v2.3 subgraphs', () => {
+    const { parse } = jest.requireActual('graphql') as typeof import('graphql');
+
+    const result = composeServices([
+      {
+        name: 'users',
+        url: 'http://users/graphql',
+        typeDefs: parse(`
+          extend schema
+            @link(
+              url: "https://specs.apollo.dev/federation/v2.12"
+              import: ["@key", "@shareable"]
+            )
+
+          type Query {
+            user(id: ID!): User
+          }
+
+          type User @key(fields: "id") {
+            id: ID!
+            name: String @shareable
+          }
+        `),
+      },
+      {
+        name: 'products',
+        url: 'http://products/graphql',
+        typeDefs: parse(`
+          extend schema
+            @link(
+              url: "https://specs.apollo.dev/federation/v2.3"
+              import: ["@key"]
+            )
+
+          type Query {
+            product(id: ID!): Product
+          }
+
+          type Product @key(fields: "id") {
+            id: ID!
+            title: String
+          }
+        `),
+      },
+    ]);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.supergraphSdl).toContain('schema');
+  });
+});


### PR DESCRIPTION
## What changed
- Upgraded Apollo composition packages to `2.14.0`.
- Added a composition test that mixes a v2.12 subgraph with a v2.3 subgraph.
- Documented the supported Federation `@link` range in the README.

## Why
- `@nestjs/graphql` now emits `https://specs.apollo.dev/federation/v2.12` by default, and the previous Apollo stack rejected that link version.

## Impact
- `supergraph-builder` now composes newer NestJS Federation subgraphs without changing its external API.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added support statement for Apollo Federation @link versions v2.3 through v2.12 and noted verification with composition v2.14.0.

* **Chores**
  * Bumped Apollo Federation package versions to v2.14.0.

* **Tests**
  * Added tests verifying compatibility when composing subgraphs using mixed Federation v2 @link versions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/revisium/supergraph-builder/pull/19)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->