### PR TITLE
fix(ci): use commit SHA (not tag object SHA) for revisium-actions pin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   build-and-push-image:
-    uses: revisium/revisium-actions/.github/workflows/docker-build.yml@174e7053ee6cc463f376441c77e19dcb85919d41 # v0.3.6
+    uses: revisium/revisium-actions/.github/workflows/docker-build.yml@184b609dcbc1e23f14021141f29226d4e6a0f1ac # v0.3.6
     with:
       image_name: ${{ github.event.repository.name }}
       context: .

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -38,7 +38,7 @@ permissions:
 jobs:
   release-train:
     name: Release train
-    uses: revisium/revisium-actions/.github/workflows/release-train.yml@174e7053ee6cc463f376441c77e19dcb85919d41 # v0.3.6
+    uses: revisium/revisium-actions/.github/workflows/release-train.yml@184b609dcbc1e23f14021141f29226d4e6a0f1ac # v0.3.6
     with:
       action: ${{ inputs.action }}
       dry_run: ${{ inputs.dry_run }}


### PR DESCRIPTION
The Build workflow on master is failing immediately with a "workflow file issue" because the previous pin `174e7053ee6cc463f376441c77e19dcb85919d41` is the **annotated tag object SHA** for `v0.3.6`, not a commit SHA.

GitHub Actions resolves `uses:` refs to a commit; a tag object SHA never matches a commit and the lookup fails.

```
$ git cat-file -t 174e7053…   # tag
$ git cat-file -t 184b609d…   # commit  ← what v0.3.6 peels to
```

Reverts both `build.yml` and `release-train.yml` to the correct commit SHA `184b609dcbc1e23f14021141f29226d4e6a0f1ac` (which is what `git rev-parse v0.3.6^{commit}` returns).

Failing run for reference: https://github.com/revisium/supergraph-builder/actions/runs/25662649795

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build and release automation infrastructure to the latest compatible versions for improved stability and reliability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/revisium/supergraph-builder/pull/21)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->