### PR TITLE
feat: per-subgraph headers for SDL introspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ SUBGRAPH_SHOP_USERS=https://users.example.com/graphql
 # Sent as:   x-api-key: secret-123
 SUBGRAPH_SHOP_USERS__HEADER_X_API_KEY=secret-123
 # Sent as:   authorization: Bearer eyJhbGc...
-SUBGRAPH_SHOP_USERS__HEADER_AUTHORIZATION=Bearer eyJhbGc...
+SUBGRAPH_SHOP_USERS__HEADER_AUTHORIZATION='Bearer eyJhbGc...'
 ```
 
 Notes:

--- a/README.md
+++ b/README.md
@@ -272,12 +272,43 @@ kubectl apply -f supergraph-builder.yaml
 
 ### Environment Variables
 
-| Variable                                | Default | Description                              |
-| --------------------------------------- | ------- | ---------------------------------------- |
-| `SUBGRAPH_<PROJECT>_<SERVICE>`          | -       | Subgraph GraphQL endpoint URL (required) |
-| `SUBGRAPH_<PROJECT>_POLL_INTERVAL_S`    | `60`    | Schema polling interval in seconds       |
-| `SUBGRAPH_<PROJECT>_MAX_RUNTIME_ERRORS` | `5`     | Maximum retry attempts                   |
-| `PORT`                                  | `8080`  | HTTP server port                         |
+| Variable                                                | Default | Description                                                                              |
+| ------------------------------------------------------- | ------- | ---------------------------------------------------------------------------------------- |
+| `SUBGRAPH_<PROJECT>_<SERVICE>`                          | -       | Subgraph GraphQL endpoint URL (required)                                                 |
+| `SUBGRAPH_<PROJECT>_<SERVICE>__HEADER_<HEADER_NAME>`    | -       | Custom HTTP header sent with the SDL introspection request (`_` → `-`, see below)        |
+| `SUBGRAPH_<PROJECT>_POLL_INTERVAL_S`                    | `60`    | Schema polling interval in seconds                                                       |
+| `SUBGRAPH_<PROJECT>_MAX_RUNTIME_ERRORS`                 | `5`     | Maximum retry attempts                                                                   |
+| `PORT`                                                  | `8080`  | HTTP server port                                                                         |
+
+### Subgraph Authentication Headers
+
+When a subgraph requires authentication for SDL introspection (e.g. an API key
+or bearer token), attach headers to that subgraph using the
+`SUBGRAPH_<PROJECT>_<SERVICE>__HEADER_<HEADER_NAME>` convention. The
+double-underscore (`__HEADER_`) separates the subgraph identifier from the
+header configuration. The header-name segment is mapped to a canonical HTTP
+header name by lowercasing it and replacing `_` with `-`.
+
+```bash
+# URL
+SUBGRAPH_SHOP_USERS=https://users.example.com/graphql
+# Sent as:   x-api-key: secret-123
+SUBGRAPH_SHOP_USERS__HEADER_X_API_KEY=secret-123
+# Sent as:   authorization: Bearer eyJhbGc...
+SUBGRAPH_SHOP_USERS__HEADER_AUTHORIZATION=Bearer eyJhbGc...
+```
+
+Notes:
+
+- Multiple headers per subgraph are supported; each header is its own env var.
+- Headers are scoped to a single subgraph; isolation between subgraphs is
+  preserved (configuring `data` doesn't affect `cms`).
+- `Content-Type` is always set to `application/json` by the fetcher and cannot
+  be overridden (case-insensitive).
+- Empty values are ignored, which is convenient when wiring a Kubernetes
+  `secretKeyRef` that may be temporarily missing during a rollout.
+- Header values are not logged. Startup logs only show the header **names** for
+  each configured subgraph.
 
 ### GraphQL Hive (Optional)
 
@@ -307,6 +338,19 @@ export SUBGRAPH_SHOP_PRODUCTS=http://localhost:4002/graphql
 # Project 2
 export SUBGRAPH_ANALYTICS_EVENTS=http://localhost:4003/graphql
 export SUBGRAPH_ANALYTICS_METRICS=http://localhost:4004/graphql
+```
+
+**Authenticated subgraph** (Kubernetes, pulling the key from a `Secret`):
+
+```yaml
+env:
+  - name: SUBGRAPH_SHOP_USERS
+    value: 'https://users.example.com/graphql'
+  - name: SUBGRAPH_SHOP_USERS__HEADER_X_API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: app-secret
+        key: USERS_API_KEY
 ```
 
 ## API

--- a/src/supergraph/__tests__/fetch.service.spec.ts
+++ b/src/supergraph/__tests__/fetch.service.spec.ts
@@ -62,7 +62,7 @@ describe('FetchService', () => {
         return {} as NodeJS.Timeout;
       });
 
-      const result = await service.fetchSchema(mockUrl, 3);
+      const result = await service.fetchSchema(mockUrl, { maxRetries: 3 });
 
       expect(result).toBe(mockSdl);
       expect(httpService.post).toHaveBeenCalledTimes(3);
@@ -96,7 +96,7 @@ describe('FetchService', () => {
 
       const logSpy = jest.spyOn(service['logger'], 'log');
 
-      const result = await service.fetchSchema(mockUrl, 2);
+      const result = await service.fetchSchema(mockUrl, { maxRetries: 2 });
 
       expect(result).toBe(mockSdl);
       expect(logSpy).toHaveBeenCalledWith(
@@ -115,7 +115,9 @@ describe('FetchService', () => {
         return {} as NodeJS.Timeout;
       });
 
-      await expect(service.fetchSchema(mockUrl, 2)).rejects.toThrow(
+      await expect(
+        service.fetchSchema(mockUrl, { maxRetries: 2 }),
+      ).rejects.toThrow(
         'Failed to fetch schema from https://example.com/graphql after 3 attempts',
       );
 
@@ -139,7 +141,9 @@ describe('FetchService', () => {
         return {} as NodeJS.Timeout;
       });
 
-      await expect(service.fetchSchema(mockUrl, 0)).rejects.toThrow(
+      await expect(
+        service.fetchSchema(mockUrl, { maxRetries: 0 }),
+      ).rejects.toThrow(
         'Invalid response structure from https://example.com/graphql: SDL not found',
       );
     });
@@ -163,7 +167,9 @@ describe('FetchService', () => {
         return {} as NodeJS.Timeout;
       });
 
-      await expect(service.fetchSchema(mockUrl, 0)).rejects.toThrow(
+      await expect(
+        service.fetchSchema(mockUrl, { maxRetries: 0 }),
+      ).rejects.toThrow(
         'Invalid response structure from https://example.com/graphql: SDL not found',
       );
     });
@@ -189,7 +195,9 @@ describe('FetchService', () => {
         return {} as NodeJS.Timeout;
       });
 
-      await expect(service.fetchSchema(mockUrl, 0)).rejects.toThrow(
+      await expect(
+        service.fetchSchema(mockUrl, { maxRetries: 0 }),
+      ).rejects.toThrow(
         'Invalid response structure from https://example.com/graphql: SDL not found',
       );
     });
@@ -221,7 +229,9 @@ describe('FetchService', () => {
 
       httpService.post.mockReturnValue(throwError(() => axiosError));
 
-      await expect(service.fetchSchema(mockUrl, 0)).rejects.toThrow(
+      await expect(
+        service.fetchSchema(mockUrl, { maxRetries: 0 }),
+      ).rejects.toThrow(
         'Failed to fetch schema from https://example.com/graphql: Request failed with status code 500',
       );
     });
@@ -238,7 +248,9 @@ describe('FetchService', () => {
           return {} as NodeJS.Timeout;
         });
 
-      await expect(service.fetchSchema(mockUrl, 2)).rejects.toThrow();
+      await expect(
+        service.fetchSchema(mockUrl, { maxRetries: 2 }),
+      ).rejects.toThrow();
 
       // Check that setTimeout was called with exponential backoff delays (with jitter)
       expect(setTimeoutSpy).toHaveBeenCalledTimes(2);
@@ -254,6 +266,75 @@ describe('FetchService', () => {
       expect(secondDelay).toBeLessThanOrEqual(2500);
     });
 
+    it('forwards custom headers alongside Content-Type', async () => {
+      const mockResponse: AxiosResponse = {
+        data: { data: { _service: { sdl: mockSdl } } },
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {} as never,
+      };
+      httpService.post.mockReturnValue(of(mockResponse));
+
+      await service.fetchSchema(mockUrl, {
+        headers: {
+          'x-api-key': 'secret-123',
+          authorization: 'Bearer abc',
+        },
+      });
+
+      expect(httpService.post).toHaveBeenCalledWith(
+        mockUrl,
+        expect.stringContaining('query GetServiceSDL'),
+        {
+          headers: {
+            'x-api-key': 'secret-123',
+            authorization: 'Bearer abc',
+            'Content-Type': 'application/json',
+          },
+        },
+      );
+    });
+
+    it('does not allow Content-Type to be overridden via headers', async () => {
+      const mockResponse: AxiosResponse = {
+        data: { data: { _service: { sdl: mockSdl } } },
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {} as never,
+      };
+      httpService.post.mockReturnValue(of(mockResponse));
+
+      await service.fetchSchema(mockUrl, {
+        headers: { 'Content-Type': 'text/plain' },
+      });
+
+      const callArgs = httpService.post.mock.calls[0];
+      const usedHeaders = (callArgs[2] as { headers: Record<string, string> })
+        .headers;
+      expect(usedHeaders['Content-Type']).toBe('application/json');
+    });
+
+    it('sends no extra headers when none are provided', async () => {
+      const mockResponse: AxiosResponse = {
+        data: { data: { _service: { sdl: mockSdl } } },
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {} as never,
+      };
+      httpService.post.mockReturnValue(of(mockResponse));
+
+      await service.fetchSchema(mockUrl);
+
+      expect(httpService.post).toHaveBeenCalledWith(
+        mockUrl,
+        expect.any(String),
+        { headers: { 'Content-Type': 'application/json' } },
+      );
+    });
+
     it('should cap backoff delay at 30 seconds', async () => {
       httpService.post.mockReturnValue(
         throwError(() => new Error('Network error')),
@@ -266,7 +347,9 @@ describe('FetchService', () => {
           return {} as NodeJS.Timeout;
         });
 
-      await expect(service.fetchSchema(mockUrl, 10)).rejects.toThrow();
+      await expect(
+        service.fetchSchema(mockUrl, { maxRetries: 10 }),
+      ).rejects.toThrow();
 
       // Check that the delay is capped at 30000ms for higher attempts
       const calls = setTimeoutSpy.mock.calls;

--- a/src/supergraph/__tests__/fetch.service.spec.ts
+++ b/src/supergraph/__tests__/fetch.service.spec.ts
@@ -316,6 +316,34 @@ describe('FetchService', () => {
       expect(usedHeaders['Content-Type']).toBe('application/json');
     });
 
+    it('strips case-variant content-type overrides before applying canonical one', async () => {
+      const mockResponse: AxiosResponse = {
+        data: { data: { _service: { sdl: mockSdl } } },
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {} as never,
+      };
+      httpService.post.mockReturnValue(of(mockResponse));
+
+      await service.fetchSchema(mockUrl, {
+        headers: {
+          'content-type': 'text/plain',
+          'x-api-key': 'preserved',
+        },
+      });
+
+      const callArgs = httpService.post.mock.calls[0];
+      const usedHeaders = (callArgs[2] as { headers: Record<string, string> })
+        .headers;
+      const lowerKeys = Object.keys(usedHeaders).map((k) => k.toLowerCase());
+      expect(lowerKeys.filter((k) => k === 'content-type')).toEqual([
+        'content-type',
+      ]);
+      expect(usedHeaders['Content-Type']).toBe('application/json');
+      expect(usedHeaders['x-api-key']).toBe('preserved');
+    });
+
     it('sends no extra headers when none are provided', async () => {
       const mockResponse: AxiosResponse = {
         data: { data: { _service: { sdl: mockSdl } } },

--- a/src/supergraph/__tests__/supergraph.service.spec.ts
+++ b/src/supergraph/__tests__/supergraph.service.spec.ts
@@ -47,11 +47,11 @@ describe('SupergraphService', () => {
       // Verify fetch was called with MAX_RUNTIME_ERRORS as maxRetries
       expect(fetchService.fetchSchema).toHaveBeenCalledWith(
         'http://localhost:4001/graphql',
-        5,
+        { maxRetries: 5, headers: undefined },
       );
       expect(fetchService.fetchSchema).toHaveBeenCalledWith(
         'http://localhost:4002/graphql',
-        5,
+        { maxRetries: 5, headers: undefined },
       );
 
       // Verify schemas were saved
@@ -126,15 +126,15 @@ describe('SupergraphService', () => {
       // Verify schemas were fetched with correct maxRetries for each project
       expect(fetchService.fetchSchema).toHaveBeenCalledWith(
         'http://localhost:4001/graphql',
-        5, // mockProjectConfig.system.MAX_RUNTIME_ERRORS
+        { maxRetries: 5, headers: undefined }, // mockProjectConfig.system.MAX_RUNTIME_ERRORS
       );
       expect(fetchService.fetchSchema).toHaveBeenCalledWith(
         'http://localhost:4002/graphql',
-        5,
+        { maxRetries: 5, headers: undefined },
       );
       expect(fetchService.fetchSchema).toHaveBeenCalledWith(
         'http://localhost:4003/graphql',
-        3, // project2.system.MAX_RUNTIME_ERRORS
+        { maxRetries: 3, headers: undefined }, // project2.system.MAX_RUNTIME_ERRORS
       );
 
       intervalSpy.mockRestore();
@@ -231,7 +231,7 @@ describe('SupergraphService', () => {
       // Verify that fetchSchema was called with MAX_RUNTIME_ERRORS as retry limit
       expect(fetchService.fetchSchema).toHaveBeenCalledWith(
         'http://localhost:4001/graphql',
-        5, // MAX_RUNTIME_ERRORS from mockProjectConfig
+        { maxRetries: 5, headers: undefined }, // MAX_RUNTIME_ERRORS from mockProjectConfig
       );
 
       intervalSpy.mockRestore();
@@ -263,11 +263,11 @@ describe('SupergraphService', () => {
       // Verify that fetchSchema was called with MAX_RUNTIME_ERRORS as maxRetries
       expect(fetchService.fetchSchema).toHaveBeenCalledWith(
         'http://localhost:4001/graphql',
-        5, // MAX_RUNTIME_ERRORS used as maxRetries
+        { maxRetries: 5, headers: undefined }, // MAX_RUNTIME_ERRORS used as maxRetries
       );
       expect(fetchService.fetchSchema).toHaveBeenCalledWith(
         'http://localhost:4002/graphql',
-        5, // MAX_RUNTIME_ERRORS used as maxRetries
+        { maxRetries: 5, headers: undefined }, // MAX_RUNTIME_ERRORS used as maxRetries
       );
 
       intervalSpy.mockRestore();
@@ -374,6 +374,53 @@ describe('SupergraphService', () => {
       // Should not set supergraph when SDL is missing
       const result = service.getSuperGraph('test-project');
       expect(result).toBeUndefined();
+
+      intervalSpy.mockRestore();
+    });
+
+    it('passes per-subgraph headers to fetchSchema', async () => {
+      (getProjectsFromEnvironment as jest.Mock).mockReturnValue([
+        {
+          project: 'demo',
+          subGraphs: [
+            {
+              name: 'data',
+              url: 'http://localhost:4001/graphql',
+              headers: { 'x-api-key': 'data-key' },
+            },
+            {
+              name: 'cms',
+              url: 'http://localhost:4002/graphql',
+              headers: { authorization: 'Bearer cms' },
+            },
+          ],
+          system: {
+            POLL_INTERVAL_S: 60,
+            HIVE_TARGET: '',
+            HIVE_ACCESS_TOKEN: '',
+            HIVE_AUTHOR: '',
+            MAX_RUNTIME_ERRORS: 5,
+          },
+        },
+      ]);
+      fetchService.fetchSchema.mockResolvedValue(mockSdl);
+      storageService.saveSchema.mockResolvedValue(void 0 as any);
+
+      const intervalSpy = jest.spyOn(rxjs, 'interval');
+      intervalSpy.mockReturnValue({
+        pipe: jest.fn().mockReturnValue({ subscribe: jest.fn() }),
+      } as any);
+
+      await service.onApplicationBootstrap();
+
+      expect(fetchService.fetchSchema).toHaveBeenCalledWith(
+        'http://localhost:4001/graphql',
+        { maxRetries: 5, headers: { 'x-api-key': 'data-key' } },
+      );
+      expect(fetchService.fetchSchema).toHaveBeenCalledWith(
+        'http://localhost:4002/graphql',
+        { maxRetries: 5, headers: { authorization: 'Bearer cms' } },
+      );
 
       intervalSpy.mockRestore();
     });

--- a/src/supergraph/fetch.service.ts
+++ b/src/supergraph/fetch.service.ts
@@ -36,8 +36,15 @@ export class FetchService {
     options: FetchSchemaOptions = {},
   ): Promise<string> {
     const { maxRetries = 3, headers: extraHeaders } = options;
+    const sanitizedExtraHeaders = extraHeaders
+      ? Object.fromEntries(
+          Object.entries(extraHeaders).filter(
+            ([name]) => name.toLowerCase() !== 'content-type',
+          ),
+        )
+      : undefined;
     const requestHeaders: Record<string, string> = {
-      ...(extraHeaders ?? {}),
+      ...sanitizedExtraHeaders,
       'Content-Type': 'application/json',
     };
     let lastError: Error = new Error('Unknown error');

--- a/src/supergraph/fetch.service.ts
+++ b/src/supergraph/fetch.service.ts
@@ -20,13 +20,26 @@ type ReturnType = {
   };
 };
 
+export type FetchSchemaOptions = {
+  maxRetries?: number;
+  headers?: Record<string, string>;
+};
+
 @Injectable()
 export class FetchService {
   private readonly logger = new Logger(FetchService.name);
 
   constructor(private readonly httpService: HttpService) {}
 
-  async fetchSchema(url: string, maxRetries: number = 3): Promise<string> {
+  async fetchSchema(
+    url: string,
+    options: FetchSchemaOptions = {},
+  ): Promise<string> {
+    const { maxRetries = 3, headers: extraHeaders } = options;
+    const requestHeaders: Record<string, string> = {
+      ...(extraHeaders ?? {}),
+      'Content-Type': 'application/json',
+    };
     let lastError: Error = new Error('Unknown error');
 
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
@@ -38,7 +51,7 @@ export class FetchService {
               JSON.stringify({
                 query: sdlQuery,
               }),
-              { headers: { 'Content-Type': 'application/json' } },
+              { headers: requestHeaders },
             )
             .pipe(
               catchError((error: AxiosError) =>

--- a/src/supergraph/supergraph.service.ts
+++ b/src/supergraph/supergraph.service.ts
@@ -67,7 +67,11 @@ export class SupergraphService implements OnApplicationBootstrap {
     const { project: id, subGraphs, system } = project;
     this.logger.log(`Project "${id}" polling every ${system.POLL_INTERVAL_S}s`);
     subGraphs.forEach(({ name, url, headers }) => {
-      const headerNames = headers ? Object.keys(headers).sort().join(', ') : '';
+      const headerNames = headers
+        ? Object.keys(headers)
+            .sort((a, b) => a.localeCompare(b))
+            .join(', ')
+        : '';
       const headerSuffix = headerNames ? ` [headers: ${headerNames}]` : '';
       this.logger.log(` - Subgraph "${name}" at ${url}${headerSuffix}`);
     });

--- a/src/supergraph/supergraph.service.ts
+++ b/src/supergraph/supergraph.service.ts
@@ -1,9 +1,14 @@
-import { Injectable, Logger, OnApplicationBootstrap } from '@nestjs/common';
+import {
+  Injectable,
+  Logger,
+  OnApplicationBootstrap,
+  OnModuleDestroy,
+} from '@nestjs/common';
 import { composeServices } from '@apollo/composition';
 import { ServiceDefinition } from '@apollo/federation-internals';
 import { parse } from 'graphql';
 import * as objectHash from 'object-hash';
-import { interval, exhaustMap, from } from 'rxjs';
+import { Subscription, interval, exhaustMap, from } from 'rxjs';
 import { FetchService } from 'src/supergraph/fetch.service';
 import { HiveCliService } from 'src/supergraph/hive.service';
 import { SchemaStorageService } from 'src/supergraph/schema-storage.service';
@@ -20,10 +25,13 @@ interface SuperGraphCacheEntry {
 }
 
 @Injectable()
-export class SupergraphService implements OnApplicationBootstrap {
+export class SupergraphService
+  implements OnApplicationBootstrap, OnModuleDestroy
+{
   private readonly logger = new Logger(SupergraphService.name);
   private readonly supergraphs = new Map<string, string>();
   private readonly caches = new Map<string, SuperGraphCacheEntry[]>();
+  private readonly pollingSubscriptions: Subscription[] = [];
 
   constructor(
     private readonly fetchService: FetchService,
@@ -76,7 +84,7 @@ export class SupergraphService implements OnApplicationBootstrap {
       this.logger.log(` - Subgraph "${name}" at ${url}${headerSuffix}`);
     });
 
-    interval(system.POLL_INTERVAL_S * 1000)
+    const subscription = interval(system.POLL_INTERVAL_S * 1000)
       .pipe(exhaustMap(() => from(this.refreshProject(project))))
       .subscribe({
         error: (error: Error) => {
@@ -86,6 +94,13 @@ export class SupergraphService implements OnApplicationBootstrap {
           process.exit(1);
         },
       });
+    this.pollingSubscriptions.push(subscription);
+  }
+
+  public onModuleDestroy(): void {
+    while (this.pollingSubscriptions.length) {
+      this.pollingSubscriptions.pop()?.unsubscribe();
+    }
   }
 
   private async refreshProject(project: ProjectConfig): Promise<void> {

--- a/src/supergraph/supergraph.service.ts
+++ b/src/supergraph/supergraph.service.ts
@@ -66,9 +66,11 @@ export class SupergraphService implements OnApplicationBootstrap {
   private startPolling(project: ProjectConfig): void {
     const { project: id, subGraphs, system } = project;
     this.logger.log(`Project "${id}" polling every ${system.POLL_INTERVAL_S}s`);
-    subGraphs.forEach(({ name, url }) =>
-      this.logger.log(` - Subgraph "${name}" at ${url}`),
-    );
+    subGraphs.forEach(({ name, url, headers }) => {
+      const headerNames = headers ? Object.keys(headers).sort().join(', ') : '';
+      const headerSuffix = headerNames ? ` [headers: ${headerNames}]` : '';
+      this.logger.log(` - Subgraph "${name}" at ${url}${headerSuffix}`);
+    });
 
     interval(system.POLL_INTERVAL_S * 1000)
       .pipe(exhaustMap(() => from(this.refreshProject(project))))
@@ -106,8 +108,11 @@ export class SupergraphService implements OnApplicationBootstrap {
     maxRetries: number,
   ): Promise<SuperGraphCacheEntry[]> {
     return Promise.all(
-      subGraphs.map(async ({ name, url }) => {
-        const sdl = await this.fetchService.fetchSchema(url, maxRetries);
+      subGraphs.map(async ({ name, url, headers }) => {
+        const sdl = await this.fetchService.fetchSchema(url, {
+          maxRetries,
+          headers,
+        });
         const hash = objectHash(sdl);
         return {
           serviceDefinition: { name, url, typeDefs: parse(sdl) },

--- a/src/supergraph/utils/__tests__/get-projects-from-env.spec.ts
+++ b/src/supergraph/utils/__tests__/get-projects-from-env.spec.ts
@@ -111,4 +111,135 @@ describe('getProjectsFromEnvironment', () => {
       MAX_RUNTIME_ERRORS: 5, // Default fallback
     });
   });
+
+  describe('subgraph headers (__HEADER_ convention)', () => {
+    test('attaches a single header to the matching subgraph', () => {
+      process.env.SUBGRAPH_DEMO_DATA = 'https://example.com/data/graphql';
+      process.env.SUBGRAPH_DEMO_DATA__HEADER_X_API_KEY = 'secret-123';
+
+      const [project] = getProjectsFromEnvironment();
+
+      expect(project.subGraphs).toEqual([
+        {
+          name: 'data',
+          url: 'https://example.com/data/graphql',
+          headers: { 'x-api-key': 'secret-123' },
+        },
+      ]);
+    });
+
+    test('attaches multiple headers to the same subgraph', () => {
+      process.env.SUBGRAPH_DEMO_DATA = 'https://example.com/data/graphql';
+      process.env.SUBGRAPH_DEMO_DATA__HEADER_AUTHORIZATION = 'Bearer abc';
+      process.env.SUBGRAPH_DEMO_DATA__HEADER_X_REQUEST_ID = 'builder';
+
+      const [project] = getProjectsFromEnvironment();
+
+      expect(project.subGraphs).toHaveLength(1);
+      expect(project.subGraphs[0]).toEqual({
+        name: 'data',
+        url: 'https://example.com/data/graphql',
+        headers: {
+          authorization: 'Bearer abc',
+          'x-request-id': 'builder',
+        },
+      });
+    });
+
+    test('isolates headers per subgraph in the same project', () => {
+      process.env.SUBGRAPH_DEMO_DATA = 'https://example.com/data/graphql';
+      process.env.SUBGRAPH_DEMO_DATA__HEADER_X_API_KEY = 'data-key';
+      process.env.SUBGRAPH_DEMO_CMS = 'https://example.com/cms/graphql';
+      process.env.SUBGRAPH_DEMO_CMS__HEADER_X_API_KEY = 'cms-key';
+
+      const [project] = getProjectsFromEnvironment();
+
+      const data = project.subGraphs.find((s) => s.name === 'data');
+      const cms = project.subGraphs.find((s) => s.name === 'cms');
+
+      expect(data?.headers).toEqual({ 'x-api-key': 'data-key' });
+      expect(cms?.headers).toEqual({ 'x-api-key': 'cms-key' });
+    });
+
+    test('omits headers field when no header env var is set', () => {
+      process.env.SUBGRAPH_DEMO_DATA = 'https://example.com/data/graphql';
+
+      const [project] = getProjectsFromEnvironment();
+
+      expect(project.subGraphs[0]).toEqual({
+        name: 'data',
+        url: 'https://example.com/data/graphql',
+      });
+      expect(project.subGraphs[0].headers).toBeUndefined();
+    });
+
+    test('supports subgraph names containing underscores', () => {
+      process.env.SUBGRAPH_SHOP_USER_API = 'https://example.com/users/graphql';
+      process.env.SUBGRAPH_SHOP_USER_API__HEADER_X_API_KEY = 'shop-key';
+
+      const [project] = getProjectsFromEnvironment();
+
+      expect(project.subGraphs).toEqual([
+        {
+          name: 'user_api',
+          url: 'https://example.com/users/graphql',
+          headers: { 'x-api-key': 'shop-key' },
+        },
+      ]);
+    });
+
+    test('skips empty header values', () => {
+      process.env.SUBGRAPH_DEMO_DATA = 'https://example.com/data/graphql';
+      process.env.SUBGRAPH_DEMO_DATA__HEADER_X_API_KEY = '';
+
+      const [project] = getProjectsFromEnvironment();
+
+      expect(project.subGraphs[0].headers).toBeUndefined();
+    });
+
+    test('skips orphan headers when the subgraph URL is not defined', () => {
+      process.env.SUBGRAPH_DEMO_DATA__HEADER_X_API_KEY = 'orphan';
+
+      const result = getProjectsFromEnvironment();
+
+      expect(result).toEqual([]);
+    });
+
+    test('skips header config with invalid header name', () => {
+      process.env.SUBGRAPH_DEMO_DATA = 'https://example.com/data/graphql';
+      // empty header name after the marker
+      process.env['SUBGRAPH_DEMO_DATA__HEADER_'] = 'value';
+
+      const [project] = getProjectsFromEnvironment();
+
+      expect(project.subGraphs[0].headers).toBeUndefined();
+    });
+
+    test('header config is order-independent (header before url)', () => {
+      // env-var iteration order is implementation-defined; the parser must
+      // not depend on URL being seen before headers.
+      process.env.SUBGRAPH_DEMO_DATA__HEADER_X_API_KEY = 'key';
+      process.env.SUBGRAPH_DEMO_DATA = 'https://example.com/data/graphql';
+
+      const [project] = getProjectsFromEnvironment();
+
+      expect(project.subGraphs).toEqual([
+        {
+          name: 'data',
+          url: 'https://example.com/data/graphql',
+          headers: { 'x-api-key': 'key' },
+        },
+      ]);
+    });
+
+    test('does not treat header env vars as additional subgraphs', () => {
+      process.env.SUBGRAPH_DEMO_DATA = 'https://example.com/data/graphql';
+      process.env.SUBGRAPH_DEMO_DATA__HEADER_AUTHORIZATION = 'Bearer x';
+
+      const [project] = getProjectsFromEnvironment();
+
+      expect(project.subGraphs).toHaveLength(1);
+      expect(project.subGraphs[0].name).toBe('data');
+    });
+  });
 });

--- a/src/supergraph/utils/get-projects-from-env.ts
+++ b/src/supergraph/utils/get-projects-from-env.ts
@@ -54,7 +54,7 @@ function tryParseHeader(
 
   if (!subGraphKey || !rawHeaderName) return null;
 
-  const headerName = rawHeaderName.toLowerCase().replace(/_/g, '-');
+  const headerName = rawHeaderName.toLowerCase().replaceAll('_', '-');
   if (!VALID_HEADER_NAME.test(headerName)) return null;
 
   return {
@@ -129,7 +129,7 @@ export function getProjectsFromEnvironment(): ProjectConfig[] {
       (s) => s.name === pending.subGraphKey,
     );
     if (!subGraph) continue;
-    if (!subGraph.headers) subGraph.headers = {};
+    subGraph.headers ??= {};
     subGraph.headers[pending.headerName] = pending.value;
   }
 

--- a/src/supergraph/utils/get-projects-from-env.ts
+++ b/src/supergraph/utils/get-projects-from-env.ts
@@ -1,6 +1,7 @@
 export type SubGraphEntry = {
   name: string;
   url: string;
+  headers?: Record<string, string>;
 };
 
 export type ProjectConfig = {
@@ -22,6 +23,9 @@ const RESERVED_KEYS_DEFAULT_VALUES: Record<RESERVED_KEYS, string> = {
   MAX_RUNTIME_ERRORS: '5',
 };
 
+const HEADER_MARKER = '__HEADER_';
+const VALID_HEADER_NAME = /^[a-z0-9-]+$/;
+
 function parseValueToNumber(raw: string, defaultValue: number = 0): number {
   const num = Number(raw);
   if (Number.isNaN(num) || num < 0) {
@@ -30,8 +34,40 @@ function parseValueToNumber(raw: string, defaultValue: number = 0): number {
   return num;
 }
 
+type PendingHeader = {
+  project: string;
+  subGraphKey: string;
+  headerName: string;
+  value: string;
+};
+
+function tryParseHeader(
+  settingKey: string,
+  envVal: string,
+  projectKey: string,
+): PendingHeader | null {
+  const markerIndex = settingKey.indexOf(HEADER_MARKER);
+  if (markerIndex < 0) return null;
+
+  const subGraphKey = settingKey.slice(0, markerIndex);
+  const rawHeaderName = settingKey.slice(markerIndex + HEADER_MARKER.length);
+
+  if (!subGraphKey || !rawHeaderName) return null;
+
+  const headerName = rawHeaderName.toLowerCase().replace(/_/g, '-');
+  if (!VALID_HEADER_NAME.test(headerName)) return null;
+
+  return {
+    project: projectKey,
+    subGraphKey: subGraphKey.toLowerCase(),
+    headerName,
+    value: envVal,
+  };
+}
+
 export function getProjectsFromEnvironment(): ProjectConfig[] {
   const projectsMap: Record<string, ProjectConfig> = {};
+  const pendingHeaders: PendingHeader[] = [];
 
   Object.entries(process.env).forEach(([envKey, envVal]) => {
     if (!envKey.startsWith('SUBGRAPH_') || !envVal) return;
@@ -64,6 +100,12 @@ export function getProjectsFromEnvironment(): ProjectConfig[] {
 
     const cfg = projectsMap[projectKey];
 
+    const headerMatch = tryParseHeader(settingKey, envVal, projectKey);
+    if (headerMatch) {
+      pendingHeaders.push(headerMatch);
+      return;
+    }
+
     if (settingKey === 'POLL_INTERVAL_S') {
       cfg.system.POLL_INTERVAL_S = parseValueToNumber(envVal, 60);
     } else if (settingKey === 'MAX_RUNTIME_ERRORS') {
@@ -80,5 +122,16 @@ export function getProjectsFromEnvironment(): ProjectConfig[] {
     }
   });
 
-  return Object.values(projectsMap);
+  for (const pending of pendingHeaders) {
+    const project = projectsMap[pending.project];
+    if (!project) continue;
+    const subGraph = project.subGraphs.find(
+      (s) => s.name === pending.subGraphKey,
+    );
+    if (!subGraph) continue;
+    if (!subGraph.headers) subGraph.headers = {};
+    subGraph.headers[pending.headerName] = pending.value;
+  }
+
+  return Object.values(projectsMap).filter((p) => p.subGraphs.length > 0);
 }

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -11,8 +11,8 @@ import {
 
 describe('AppModule (e2e)', () => {
   const ORIGINAL_ENV = process.env;
-  let app: INestApplication<App>;
-  let fixture: SubgraphFixture;
+  let app: INestApplication<App> | undefined;
+  let fixture: SubgraphFixture | undefined;
 
   beforeEach(async () => {
     process.env = { ...ORIGINAL_ENV };
@@ -34,14 +34,21 @@ describe('AppModule (e2e)', () => {
 
   afterEach(async () => {
     try {
-      await app.close();
-      await fixture.close();
+      if (app) {
+        await app.close();
+        app = undefined;
+      }
+      if (fixture) {
+        await fixture.close();
+        fixture = undefined;
+      }
     } finally {
       process.env = ORIGINAL_ENV;
     }
   });
 
   it('exposes liveness probe', () => {
+    if (!app) throw new Error('app not initialized');
     return request(app.getHttpServer())
       .get('/health/liveness')
       .expect(200)
@@ -52,6 +59,7 @@ describe('AppModule (e2e)', () => {
   });
 
   it('exposes composed supergraph for the configured project', () => {
+    if (!app) throw new Error('app not initialized');
     return request(app.getHttpServer())
       .get('/supergraph/demo')
       .expect(200)
@@ -62,6 +70,7 @@ describe('AppModule (e2e)', () => {
   });
 
   it('returns 404 for unknown projects', () => {
+    if (!app) throw new Error('app not initialized');
     return request(app.getHttpServer()).get('/supergraph/unknown').expect(404);
   });
 });

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -1,50 +1,18 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
-import * as http from 'node:http';
-import { AddressInfo } from 'node:net';
 import * as request from 'supertest';
+import type { Response } from 'supertest';
 import { App } from 'supertest/types';
 import { AppModule } from './../src/app.module';
-
-const SDL = `
-extend schema
-  @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@key"])
-
-type Query {
-  hello: String
-}
-`;
-
-function closeServer(server: http.Server): Promise<void> {
-  return new Promise<void>((done) => server.close(() => done()));
-}
-
-function listenOnRandomPort(server: http.Server): Promise<number> {
-  return new Promise((resolve) => {
-    server.listen(0, '127.0.0.1', () => {
-      const { port } = server.address() as AddressInfo;
-      resolve(port);
-    });
-  });
-}
-
-async function startSubgraphFixture(): Promise<{
-  port: number;
-  close: () => Promise<void>;
-}> {
-  const server = http.createServer((_req, res) => {
-    res.statusCode = 200;
-    res.setHeader('Content-Type', 'application/json');
-    res.end(JSON.stringify({ data: { _service: { sdl: SDL } } }));
-  });
-  const port = await listenOnRandomPort(server);
-  return { port, close: () => closeServer(server) };
-}
+import {
+  startSubgraphFixture,
+  SubgraphFixture,
+} from './helpers/subgraph-fixture';
 
 describe('AppModule (e2e)', () => {
   const ORIGINAL_ENV = process.env;
   let app: INestApplication<App>;
-  let fixture: Awaited<ReturnType<typeof startSubgraphFixture>>;
+  let fixture: SubgraphFixture;
 
   beforeEach(async () => {
     process.env = { ...ORIGINAL_ENV };
@@ -77,7 +45,7 @@ describe('AppModule (e2e)', () => {
     return request(app.getHttpServer())
       .get('/health/liveness')
       .expect(200)
-      .expect((res) => {
+      .expect((res: Response) => {
         const body = res.body as { status?: string };
         expect(body.status).toBe('ok');
       });
@@ -88,7 +56,7 @@ describe('AppModule (e2e)', () => {
       .get('/supergraph/demo')
       .expect(200)
       .expect('Content-Type', /text\/plain/)
-      .expect((res) => {
+      .expect((res: Response) => {
         expect(res.text).toContain('schema');
       });
   });

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -73,7 +73,8 @@ describe('AppModule (e2e)', () => {
       .get('/health/liveness')
       .expect(200)
       .expect((res) => {
-        expect(res.body.status).toBe('ok');
+        const body = res.body as { status?: string };
+        expect(body.status).toBe('ok');
       });
   });
 
@@ -88,8 +89,6 @@ describe('AppModule (e2e)', () => {
   });
 
   it('returns 404 for unknown projects', () => {
-    return request(app.getHttpServer())
-      .get('/supergraph/unknown')
-      .expect(404);
+    return request(app.getHttpServer()).get('/supergraph/unknown').expect(404);
   });
 });

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -1,13 +1,59 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
+import * as http from 'node:http';
+import { AddressInfo } from 'node:net';
 import * as request from 'supertest';
 import { App } from 'supertest/types';
 import { AppModule } from './../src/app.module';
 
-describe('AppController (e2e)', () => {
+const SDL = `
+extend schema
+  @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@key"])
+
+type Query {
+  hello: String
+}
+`;
+
+function startSubgraphFixture(): Promise<{
+  port: number;
+  close: () => Promise<void>;
+}> {
+  const server = http.createServer((_req, res) => {
+    res.statusCode = 200;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ data: { _service: { sdl: SDL } } }));
+  });
+
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address() as AddressInfo;
+      resolve({
+        port,
+        close: () =>
+          new Promise<void>((done) => {
+            server.close(() => done());
+          }),
+      });
+    });
+  });
+}
+
+describe('AppModule (e2e)', () => {
+  const ORIGINAL_ENV = process.env;
   let app: INestApplication<App>;
+  let fixture: Awaited<ReturnType<typeof startSubgraphFixture>>;
 
   beforeEach(async () => {
+    process.env = { ...ORIGINAL_ENV };
+    Object.keys(process.env)
+      .filter((k) => k.startsWith('SUBGRAPH_'))
+      .forEach((k) => delete process.env[k]);
+
+    fixture = await startSubgraphFixture();
+    process.env.SUBGRAPH_DEMO_DATA = `http://127.0.0.1:${fixture.port}/graphql`;
+    process.env.SUBGRAPH_DEMO_POLL_INTERVAL_S = '9999';
+
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [AppModule],
     }).compile();
@@ -16,10 +62,34 @@ describe('AppController (e2e)', () => {
     await app.init();
   });
 
-  it('/ (GET)', () => {
+  afterEach(async () => {
+    await app.close();
+    await fixture.close();
+    process.env = ORIGINAL_ENV;
+  });
+
+  it('exposes liveness probe', () => {
     return request(app.getHttpServer())
-      .get('/')
+      .get('/health/liveness')
       .expect(200)
-      .expect('Hello World!');
+      .expect((res) => {
+        expect(res.body.status).toBe('ok');
+      });
+  });
+
+  it('exposes composed supergraph for the configured project', () => {
+    return request(app.getHttpServer())
+      .get('/supergraph/demo')
+      .expect(200)
+      .expect('Content-Type', /text\/plain/)
+      .expect((res) => {
+        expect(res.text).toContain('schema');
+      });
+  });
+
+  it('returns 404 for unknown projects', () => {
+    return request(app.getHttpServer())
+      .get('/supergraph/unknown')
+      .expect(404);
   });
 });

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -15,7 +15,20 @@ type Query {
 }
 `;
 
-function startSubgraphFixture(): Promise<{
+function closeServer(server: http.Server): Promise<void> {
+  return new Promise<void>((done) => server.close(() => done()));
+}
+
+function listenOnRandomPort(server: http.Server): Promise<number> {
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address() as AddressInfo;
+      resolve(port);
+    });
+  });
+}
+
+async function startSubgraphFixture(): Promise<{
   port: number;
   close: () => Promise<void>;
 }> {
@@ -24,19 +37,8 @@ function startSubgraphFixture(): Promise<{
     res.setHeader('Content-Type', 'application/json');
     res.end(JSON.stringify({ data: { _service: { sdl: SDL } } }));
   });
-
-  return new Promise((resolve) => {
-    server.listen(0, '127.0.0.1', () => {
-      const { port } = server.address() as AddressInfo;
-      resolve({
-        port,
-        close: () =>
-          new Promise<void>((done) => {
-            server.close(() => done());
-          }),
-      });
-    });
-  });
+  const port = await listenOnRandomPort(server);
+  return { port, close: () => closeServer(server) };
 }
 
 describe('AppModule (e2e)', () => {
@@ -63,9 +65,12 @@ describe('AppModule (e2e)', () => {
   });
 
   afterEach(async () => {
-    await app.close();
-    await fixture.close();
-    process.env = ORIGINAL_ENV;
+    try {
+      await app.close();
+      await fixture.close();
+    } finally {
+      process.env = ORIGINAL_ENV;
+    }
   });
 
   it('exposes liveness probe', () => {

--- a/test/helpers/subgraph-fixture.ts
+++ b/test/helpers/subgraph-fixture.ts
@@ -1,0 +1,70 @@
+import * as http from 'node:http';
+import { AddressInfo } from 'node:net';
+
+export type IncomingRequest = {
+  url?: string;
+  headers: http.IncomingHttpHeaders;
+  body: string;
+};
+
+export function closeServer(server: http.Server): Promise<void> {
+  return new Promise<void>((done) => server.close(() => done()));
+}
+
+export function listenOnRandomPort(server: http.Server): Promise<number> {
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address() as AddressInfo;
+      resolve(port);
+    });
+  });
+}
+
+function recordRequest(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  requests: IncomingRequest[],
+  sdl: string,
+): void {
+  const chunks: Buffer[] = [];
+  req.on('data', (chunk: Buffer) => chunks.push(chunk));
+  req.on('end', () => {
+    requests.push({
+      url: req.url,
+      headers: req.headers,
+      body: Buffer.concat(chunks).toString('utf-8'),
+    });
+    res.statusCode = 200;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ data: { _service: { sdl } } }));
+  });
+}
+
+export type SubgraphFixture = {
+  port: number;
+  requests: IncomingRequest[];
+  close: () => Promise<void>;
+};
+
+export function makeFederationSdl(fieldName: string = 'hello'): string {
+  return `
+extend schema
+  @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@key"])
+
+type Query {
+  ${fieldName}: String
+}
+`;
+}
+
+export async function startSubgraphFixture(
+  fieldName: string = 'hello',
+): Promise<SubgraphFixture> {
+  const requests: IncomingRequest[] = [];
+  const sdl = makeFederationSdl(fieldName);
+  const server = http.createServer((req, res) =>
+    recordRequest(req, res, requests, sdl),
+  );
+  const port = await listenOnRandomPort(server);
+  return { port, requests, close: () => closeServer(server) };
+}

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -1,5 +1,6 @@
 {
   "moduleFileExtensions": ["js", "json", "ts"],
+  "modulePaths": ["<rootDir>/.."],
   "rootDir": ".",
   "testEnvironment": "node",
   "testRegex": ".e2e-spec.ts$",

--- a/test/subgraph-headers.e2e-spec.ts
+++ b/test/subgraph-headers.e2e-spec.ts
@@ -21,47 +21,56 @@ type IncomingRequest = {
   body: string;
 };
 
-function startSubgraphFixture(fieldName: string = 'hello'): Promise<{
+function recordRequest(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  requests: IncomingRequest[],
+  sdl: string,
+): void {
+  const chunks: Buffer[] = [];
+  req.on('data', (chunk: Buffer) => chunks.push(chunk));
+  req.on('end', () => {
+    requests.push({
+      url: req.url,
+      headers: req.headers,
+      body: Buffer.concat(chunks).toString('utf-8'),
+    });
+    res.statusCode = 200;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ data: { _service: { sdl } } }));
+  });
+}
+
+function closeServer(server: http.Server): Promise<void> {
+  return new Promise<void>((done) => server.close(() => done()));
+}
+
+function listenOnRandomPort(server: http.Server): Promise<number> {
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address() as AddressInfo;
+      resolve(port);
+    });
+  });
+}
+
+async function startSubgraphFixture(fieldName: string = 'hello'): Promise<{
   port: number;
   requests: IncomingRequest[];
   close: () => Promise<void>;
 }> {
   const requests: IncomingRequest[] = [];
   const sdl = makeSdl(fieldName);
-
-  const server = http.createServer((req, res) => {
-    const chunks: Buffer[] = [];
-    req.on('data', (chunk: Buffer) => chunks.push(chunk));
-    req.on('end', () => {
-      requests.push({
-        url: req.url,
-        headers: req.headers,
-        body: Buffer.concat(chunks).toString('utf-8'),
-      });
-      res.statusCode = 200;
-      res.setHeader('Content-Type', 'application/json');
-      res.end(JSON.stringify({ data: { _service: { sdl } } }));
-    });
-  });
-
-  return new Promise((resolve) => {
-    server.listen(0, '127.0.0.1', () => {
-      const { port } = server.address() as AddressInfo;
-      resolve({
-        port,
-        requests,
-        close: () =>
-          new Promise<void>((done) => {
-            server.close(() => done());
-          }),
-      });
-    });
-  });
+  const server = http.createServer((req, res) =>
+    recordRequest(req, res, requests, sdl),
+  );
+  const port = await listenOnRandomPort(server);
+  return { port, requests, close: () => closeServer(server) };
 }
 
 describe('Subgraph headers (e2e)', () => {
   const ORIGINAL_ENV = process.env;
-  let fixture: Awaited<ReturnType<typeof startSubgraphFixture>>;
+  let fixture: Awaited<ReturnType<typeof startSubgraphFixture>> | undefined;
   let app: INestApplication | undefined;
 
   beforeEach(async () => {
@@ -74,15 +83,22 @@ describe('Subgraph headers (e2e)', () => {
   });
 
   afterEach(async () => {
-    if (app) {
-      await app.close();
-      app = undefined;
+    try {
+      if (app) {
+        await app.close();
+        app = undefined;
+      }
+      if (fixture) {
+        await fixture.close();
+        fixture = undefined;
+      }
+    } finally {
+      process.env = ORIGINAL_ENV;
     }
-    await fixture.close();
-    process.env = ORIGINAL_ENV;
   });
 
   it('forwards configured headers to subgraph SDL introspection requests', async () => {
+    if (!fixture) throw new Error('fixture not initialized');
     process.env.SUBGRAPH_DEMO_DATA = `http://127.0.0.1:${fixture.port}/graphql`;
     process.env.SUBGRAPH_DEMO_DATA__HEADER_X_API_KEY = 'secret-from-env';
     process.env.SUBGRAPH_DEMO_DATA__HEADER_AUTHORIZATION = 'Bearer token-xyz';
@@ -104,6 +120,7 @@ describe('Subgraph headers (e2e)', () => {
   });
 
   it('omits auth headers when no header env var is configured', async () => {
+    if (!fixture) throw new Error('fixture not initialized');
     process.env.SUBGRAPH_DEMO_DATA = `http://127.0.0.1:${fixture.port}/graphql`;
     process.env.SUBGRAPH_DEMO_POLL_INTERVAL_S = '9999';
 
@@ -121,6 +138,7 @@ describe('Subgraph headers (e2e)', () => {
   });
 
   it('isolates headers between subgraphs in the same project', async () => {
+    if (!fixture) throw new Error('fixture not initialized');
     const second = await startSubgraphFixture('greetings');
     try {
       process.env.SUBGRAPH_DEMO_DATA = `http://127.0.0.1:${fixture.port}/graphql`;
@@ -135,6 +153,8 @@ describe('Subgraph headers (e2e)', () => {
       app = moduleFixture.createNestApplication();
       await app.init();
 
+      expect(fixture.requests.length).toBeGreaterThanOrEqual(1);
+      expect(second.requests.length).toBeGreaterThanOrEqual(1);
       expect(fixture.requests[0].headers['x-api-key']).toBe('data-key');
       expect(second.requests[0].headers['x-api-key']).toBe('cms-key');
     } finally {

--- a/test/subgraph-headers.e2e-spec.ts
+++ b/test/subgraph-headers.e2e-spec.ts
@@ -1,76 +1,14 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
-import * as http from 'node:http';
-import { AddressInfo } from 'node:net';
 import { AppModule } from './../src/app.module';
-
-function makeSdl(fieldName: string): string {
-  return `
-extend schema
-  @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@key"])
-
-type Query {
-  ${fieldName}: String
-}
-`;
-}
-
-type IncomingRequest = {
-  url?: string;
-  headers: http.IncomingHttpHeaders;
-  body: string;
-};
-
-function recordRequest(
-  req: http.IncomingMessage,
-  res: http.ServerResponse,
-  requests: IncomingRequest[],
-  sdl: string,
-): void {
-  const chunks: Buffer[] = [];
-  req.on('data', (chunk: Buffer) => chunks.push(chunk));
-  req.on('end', () => {
-    requests.push({
-      url: req.url,
-      headers: req.headers,
-      body: Buffer.concat(chunks).toString('utf-8'),
-    });
-    res.statusCode = 200;
-    res.setHeader('Content-Type', 'application/json');
-    res.end(JSON.stringify({ data: { _service: { sdl } } }));
-  });
-}
-
-function closeServer(server: http.Server): Promise<void> {
-  return new Promise<void>((done) => server.close(() => done()));
-}
-
-function listenOnRandomPort(server: http.Server): Promise<number> {
-  return new Promise((resolve) => {
-    server.listen(0, '127.0.0.1', () => {
-      const { port } = server.address() as AddressInfo;
-      resolve(port);
-    });
-  });
-}
-
-async function startSubgraphFixture(fieldName: string = 'hello'): Promise<{
-  port: number;
-  requests: IncomingRequest[];
-  close: () => Promise<void>;
-}> {
-  const requests: IncomingRequest[] = [];
-  const sdl = makeSdl(fieldName);
-  const server = http.createServer((req, res) =>
-    recordRequest(req, res, requests, sdl),
-  );
-  const port = await listenOnRandomPort(server);
-  return { port, requests, close: () => closeServer(server) };
-}
+import {
+  startSubgraphFixture,
+  SubgraphFixture,
+} from './helpers/subgraph-fixture';
 
 describe('Subgraph headers (e2e)', () => {
   const ORIGINAL_ENV = process.env;
-  let fixture: Awaited<ReturnType<typeof startSubgraphFixture>> | undefined;
+  let fixture: SubgraphFixture | undefined;
   let app: INestApplication | undefined;
 
   beforeEach(async () => {

--- a/test/subgraph-headers.e2e-spec.ts
+++ b/test/subgraph-headers.e2e-spec.ts
@@ -1,0 +1,144 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as http from 'node:http';
+import { AddressInfo } from 'node:net';
+import { AppModule } from './../src/app.module';
+
+function makeSdl(fieldName: string): string {
+  return `
+extend schema
+  @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@key"])
+
+type Query {
+  ${fieldName}: String
+}
+`;
+}
+
+type IncomingRequest = {
+  url?: string;
+  headers: http.IncomingHttpHeaders;
+  body: string;
+};
+
+function startSubgraphFixture(fieldName: string = 'hello'): Promise<{
+  port: number;
+  requests: IncomingRequest[];
+  close: () => Promise<void>;
+}> {
+  const requests: IncomingRequest[] = [];
+  const sdl = makeSdl(fieldName);
+
+  const server = http.createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk: Buffer) => chunks.push(chunk));
+    req.on('end', () => {
+      requests.push({
+        url: req.url,
+        headers: req.headers,
+        body: Buffer.concat(chunks).toString('utf-8'),
+      });
+      res.statusCode = 200;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ data: { _service: { sdl } } }));
+    });
+  });
+
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address() as AddressInfo;
+      resolve({
+        port,
+        requests,
+        close: () =>
+          new Promise<void>((done) => {
+            server.close(() => done());
+          }),
+      });
+    });
+  });
+}
+
+describe('Subgraph headers (e2e)', () => {
+  const ORIGINAL_ENV = process.env;
+  let fixture: Awaited<ReturnType<typeof startSubgraphFixture>>;
+  let app: INestApplication | undefined;
+
+  beforeEach(async () => {
+    process.env = { ...ORIGINAL_ENV };
+    // Strip any inherited SUBGRAPH_* keys so the test env is hermetic.
+    Object.keys(process.env)
+      .filter((k) => k.startsWith('SUBGRAPH_'))
+      .forEach((k) => delete process.env[k]);
+    fixture = await startSubgraphFixture();
+  });
+
+  afterEach(async () => {
+    if (app) {
+      await app.close();
+      app = undefined;
+    }
+    await fixture.close();
+    process.env = ORIGINAL_ENV;
+  });
+
+  it('forwards configured headers to subgraph SDL introspection requests', async () => {
+    process.env.SUBGRAPH_DEMO_DATA = `http://127.0.0.1:${fixture.port}/graphql`;
+    process.env.SUBGRAPH_DEMO_DATA__HEADER_X_API_KEY = 'secret-from-env';
+    process.env.SUBGRAPH_DEMO_DATA__HEADER_AUTHORIZATION = 'Bearer token-xyz';
+    // Long poll interval so the test only sees the initial bootstrap fetch.
+    process.env.SUBGRAPH_DEMO_POLL_INTERVAL_S = '9999';
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+    app = moduleFixture.createNestApplication();
+    await app.init();
+
+    expect(fixture.requests.length).toBeGreaterThanOrEqual(1);
+    const captured = fixture.requests[0];
+    expect(captured.headers['x-api-key']).toBe('secret-from-env');
+    expect(captured.headers['authorization']).toBe('Bearer token-xyz');
+    expect(captured.headers['content-type']).toBe('application/json');
+    expect(captured.body).toContain('GetServiceSDL');
+  });
+
+  it('omits auth headers when no header env var is configured', async () => {
+    process.env.SUBGRAPH_DEMO_DATA = `http://127.0.0.1:${fixture.port}/graphql`;
+    process.env.SUBGRAPH_DEMO_POLL_INTERVAL_S = '9999';
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+    app = moduleFixture.createNestApplication();
+    await app.init();
+
+    expect(fixture.requests.length).toBeGreaterThanOrEqual(1);
+    const captured = fixture.requests[0];
+    expect(captured.headers['x-api-key']).toBeUndefined();
+    expect(captured.headers['authorization']).toBeUndefined();
+    expect(captured.headers['content-type']).toBe('application/json');
+  });
+
+  it('isolates headers between subgraphs in the same project', async () => {
+    const second = await startSubgraphFixture('greetings');
+    try {
+      process.env.SUBGRAPH_DEMO_DATA = `http://127.0.0.1:${fixture.port}/graphql`;
+      process.env.SUBGRAPH_DEMO_DATA__HEADER_X_API_KEY = 'data-key';
+      process.env.SUBGRAPH_DEMO_CMS = `http://127.0.0.1:${second.port}/graphql`;
+      process.env.SUBGRAPH_DEMO_CMS__HEADER_X_API_KEY = 'cms-key';
+      process.env.SUBGRAPH_DEMO_POLL_INTERVAL_S = '9999';
+
+      const moduleFixture: TestingModule = await Test.createTestingModule({
+        imports: [AppModule],
+      }).compile();
+      app = moduleFixture.createNestApplication();
+      await app.init();
+
+      expect(fixture.requests[0].headers['x-api-key']).toBe('data-key');
+      expect(second.requests[0].headers['x-api-key']).toBe('cms-key');
+    } finally {
+      await second.close();
+    }
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-subgraph HTTP headers via SUBGRAPH_<PROJECT>_<SERVICE>__HEADER_<HEADER_NAME>; forwarded but cannot override Content-Type: application/json.
  * Schema fetcher now accepts an options object to configure max retries and per-request headers.

* **Bug Fixes**
  * Background subgraph pollers are cleanly unsubscribed on shutdown.

* **Tests**
  * Expanded unit and e2e coverage for header forwarding, retry/backoff behavior, header parsing, and per-subgraph isolation.

* **Documentation**
  * README updated with header env-var convention and examples.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/revisium/supergraph-builder/pull/22)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->